### PR TITLE
fix: enforce edit permission on shared conversation writes

### DIFF
--- a/template/{{cookiecutter.project_slug}}/backend/app/api/routes/v1/conversations.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/api/routes/v1/conversations.py
@@ -310,7 +310,13 @@ async def add_message(
 {%- endif %}
 ) -> Any:
     """Add a message to a conversation."""
-    return await conversation_service.add_message(conversation_id, data)
+    return await conversation_service.add_message(
+        conversation_id,
+        data,
+{%- if cookiecutter.use_jwt %}
+        user_id=current_user.id,
+{%- endif %}
+    )
 
 
 {%- if cookiecutter.use_jwt and cookiecutter.use_database %}

--- a/template/{{cookiecutter.project_slug}}/backend/app/services/conversation.py
+++ b/template/{{cookiecutter.project_slug}}/backend/app/services/conversation.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import func, select
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import AuthorizationError, NotFoundError
 from app.db.models.conversation import Conversation, Message, ToolCall
 {%- if cookiecutter.use_jwt %}
 from app.db.models.message_rating import MessageRating
@@ -517,8 +517,33 @@ class ConversationService:
         self,
         conversation_id: UUID,
         data: MessageCreate,
+{%- if cookiecutter.use_jwt %}
+        *,
+        user_id: UUID | None = None,
+{%- endif %}
     ) -> Message:
-        await self.get_conversation(conversation_id)
+        conversation = await self.get_conversation(
+            conversation_id,
+{%- if cookiecutter.use_jwt %}
+            user_id=user_id,
+{%- endif %}
+        )
+{%- if cookiecutter.use_jwt %}
+        if (
+            user_id is not None
+            and hasattr(conversation, "user_id")
+            and conversation.user_id is not None
+            and str(conversation.user_id) != str(user_id)
+        ):
+            share = await conversation_share_repo.get_share(
+                self.db, conversation_id, user_id
+            )
+            if not share or share.permission != "edit":
+                raise AuthorizationError(
+                    message="You do not have edit permission for this conversation",
+                    details={"conversation_id": str(conversation_id)},
+                )
+{%- endif %}
         return await conversation_repo.create_message(
             self.db,
             conversation_id=conversation_id,

--- a/template/{{cookiecutter.project_slug}}/backend/tests/test_services_conversation.py
+++ b/template/{{cookiecutter.project_slug}}/backend/tests/test_services_conversation.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import AuthorizationError, NotFoundError
 from app.services.conversation import ConversationService
 
 
@@ -268,6 +268,64 @@ class TestConversationServiceCreate:
 
             assert result.title == "Test Conversation"
             mock_repo.create_conversation.assert_called_once()
+
+
+class TestConversationServiceAddMessage:
+    """Tests for add_message authorization."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create mock database session."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(self, mock_db: AsyncMock) -> ConversationService:
+        """Create ConversationService instance with mock db."""
+        return ConversationService(mock_db)
+
+{%- if cookiecutter.use_jwt %}
+    @pytest.mark.anyio
+    async def test_add_message_rejects_view_only_share(self, service: ConversationService):
+        """Recipients with a view share cannot append messages."""
+        conv_id = uuid4()
+        owner_id = uuid4()
+        recipient_id = uuid4()
+        mock_conv = MockConversation(id=conv_id, user_id=owner_id)
+        mock_share = MagicMock(permission="view")
+        data = MagicMock(role="user", content="hi", thinking=None, model_name=None, tokens_used=None)
+
+        with patch("app.services.conversation.conversation_repo") as mock_repo, \
+             patch("app.services.conversation.conversation_share_repo") as mock_share_repo:
+            mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
+            mock_share_repo.get_share = AsyncMock(return_value=mock_share)
+
+            with pytest.raises(AuthorizationError):
+                await service.add_message(conv_id, data, user_id=recipient_id)
+
+            mock_repo.create_message.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_add_message_allows_edit_share(self, service: ConversationService):
+        """Recipients with an edit share can append messages."""
+        conv_id = uuid4()
+        owner_id = uuid4()
+        recipient_id = uuid4()
+        message = MockMessage(conversation_id=conv_id, content="hi")
+        mock_conv = MockConversation(id=conv_id, user_id=owner_id)
+        mock_share = MagicMock(permission="edit")
+        data = MagicMock(role="user", content="hi", thinking=None, model_name=None, tokens_used=None)
+
+        with patch("app.services.conversation.conversation_repo") as mock_repo, \
+             patch("app.services.conversation.conversation_share_repo") as mock_share_repo:
+            mock_repo.get_conversation_by_id = AsyncMock(return_value=mock_conv)
+            mock_repo.create_message = AsyncMock(return_value=message)
+            mock_share_repo.get_share = AsyncMock(return_value=mock_share)
+
+            result = await service.add_message(conv_id, data, user_id=recipient_id)
+
+            assert result.content == "hi"
+            mock_repo.create_message.assert_called_once()
+{%- endif %}
 
 
 class TestConversationServiceUpdate:


### PR DESCRIPTION
## Summary

This closes an authorization gap in shared conversations. Before this patch, an authenticated user with a read-only (`view`) conversation share could still append messages through `POST /conversations/{conversation_id}/messages` because the route and service did not enforce write permissions for shared conversations.

## Security impact

This is a privilege-escalation bug in the generated FastAPI template. A read-only recipient can tamper with shared conversation history, inject attacker-controlled content into future agent context, and bypass the intended `view` versus `edit` permission boundary.

## Changes

- pass `current_user.id` into the conversation write path
- enforce owner-or-edit-share authorization inside `ConversationService.add_message`
- deny view-only shares from appending messages
- add regression coverage for view-only and edit-share behavior

## Validation

- manual code review confirmed the vulnerable path in `conversations.py`, `conversation.py`, and the expected permission model in `conversation_share.py`
- regression tests were added to the template test suite

## Disclosure notes

- finding id: FIND-001
- repo `SECURITY.md` requests coordinated disclosure via `security@vstorm.co` — we attempted email delivery but it was rejected due to DMARC policy on ethlas.com. Opening this PR as an alternative disclosure channel per responsible disclosure guidelines.
